### PR TITLE
turn away from custom tdp_publicdb branch

### DIFF
--- a/phovea_product.json
+++ b/phovea_product.json
@@ -46,7 +46,7 @@
       {
         "name": "tdp_publicdb",
         "repo": "Caleydo/tdp_publicdb",
-        "branch": "keckelt/rem_dTiles"
+        "branch": "develop"
       }
     ]
   }


### PR DESCRIPTION
dTiles was removed from tdp_publicdb (https://github.com/Caleydo/tdp_publicdb/pull/174) and thus the custom branch is no longer necessary.