### PR TITLE
Fix Checkout of Product Repos

### DIFF
--- a/build.js
+++ b/build.js
@@ -97,7 +97,7 @@
  
  function toRepoUrlWithUser(url) {
    const repo = toRepoUrl(url);
-   if (repo.startsWith('git@')) { // ssh
+   if (repo.startsWith('git+ssh@')) { // ssh
      return repo;
    }
    const usernameAndPassword = guessUserName(repo);


### PR DESCRIPTION

Build script tried to guess the username which failed and aborted the build process, see https://app.circleci.com/pipelines/github/Caleydo/coral_product/354/workflows/14cd5cc1-97b1-4214-8535-84c675c247ca/jobs/377

```
ERROR extra building  TypeError: Cannot read property '1' of null
    at guessUserName (/home/circleci/phovea/build.js:88:43)
    at toRepoUrlWithUser (/home/circleci/phovea/build.js:103:32)
    at cloneRepo (/home/circleci/phovea/build.js:324:12)
    at steps.<computed> (/home/circleci/phovea/build.js:816:60)
    at tryCatcher (/home/circleci/phovea/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/circleci/phovea/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/home/circleci/phovea/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromiseCtx (/home/circleci/phovea/node_modules/bluebird/js/release/promise.js:641:10)
    at _drainQueueStep (/home/circleci/phovea/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/home/circleci/phovea/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/circleci/phovea/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/circleci/phovea/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:464:21)

Exited with code exit status 1

CircleCI received exit code 1

```