### PR TITLE
Change SCSS import for Font Awesome 6

### DIFF
--- a/templates/web/workspace.scss
+++ b/templates/web/workspace.scss
@@ -25,10 +25,9 @@
 @import "~tdp_gene/dist/scss/abstracts/variables";
 @import "~tdp_publicdb/dist/scss/abstracts/variables";
 @import "~tourdino/dist/scss/abstracts/variables";
-@import "~@fortawesome/fontawesome-free/scss/variables";
+@import "~tdp_core/dist/scss/fontawesome";
 
 // import mixins
-@import "~@fortawesome/fontawesome-free/scss/mixins";
 @import "~tdp_core/dist/scss/abstracts/mixins";
 
 @debug('import plugin main scss');


### PR DESCRIPTION
Requires https://github.com/datavisyn/tdp_core/pull/732

### Summary

- Change SCSS import for Font Awesome 6


**Please don't merge this PR until https://github.com/datavisyn/tdp_core/pull/732 is merged!**