### PR TITLE
Kokiri - Dependencies: Reference releases instead of develop

### DIFF
--- a/phovea_product.json
+++ b/phovea_product.json
@@ -8,7 +8,7 @@
       {
         "name": "coral",
         "repo": "Caleydo/coral",
-        "branch": "comparison_2023_fix_deps"
+        "branch": "comparison_2023"
       },
       {
         "name": "phovea_security_store_generated",
@@ -31,7 +31,7 @@
       {
         "name": "coral",
         "repo": "Caleydo/coral",
-        "branch": "comparison_2023_fix_deps"
+        "branch": "comparison_2023"
       },
       {
         "name": "phovea_security_store_generated",

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -8,7 +8,7 @@
       {
         "name": "coral",
         "repo": "Caleydo/coral",
-        "branch": "comparison_2023"
+        "branch": "comparison_2023_fix_deps"
       },
       {
         "name": "phovea_security_store_generated",
@@ -31,7 +31,7 @@
       {
         "name": "coral",
         "repo": "Caleydo/coral",
-        "branch": "comparison_2023"
+        "branch": "comparison_2023_fix_deps"
       },
       {
         "name": "phovea_security_store_generated",

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -3,7 +3,7 @@
     "type": "web",
     "label": "coral_frontend",
     "repo": "Caleydo/coral_public",
-    "branch": "develop",
+    "branch": "v4.0.0",
     "additional": [
       {
         "name": "coral",
@@ -13,12 +13,12 @@
       {
         "name": "phovea_security_store_generated",
         "repo": "datavisyn/phovea_security_store_generated",
-        "branch": "develop"
+        "branch": "v15.0.0"
       },
       {
         "name": "tdp_core",
         "repo": "datavisyn/tdp_core",
-        "branch": "develop"
+        "branch": "v20.0.0"
       }
     ]
   },
@@ -26,7 +26,7 @@
     "type": "api",
     "label": "coral_backend",
     "repo": "datavisyn/tdp_core",
-    "branch": "develop",
+    "branch": "v20.0.0",
     "additional": [
       {
         "name": "coral",
@@ -36,12 +36,12 @@
       {
         "name": "phovea_security_store_generated",
         "repo": "datavisyn/phovea_security_store_generated",
-        "branch": "develop"
+        "branch": "v15.0.0"
       },
       {
         "name": "tdp_publicdb",
         "repo": "Caleydo/tdp_publicdb",
-        "branch": "develop"
+        "branch": "v14.0.0"
       }
     ]
   },


### PR DESCRIPTION
Use fixed versions for Caleydo/TDP/visyn dependencies.